### PR TITLE
fix(proxmox-controller): idempotent vm_clone + stop VM before cloud-init config

### DIFF
--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_set_variables.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_set_variables.yaml
@@ -11,6 +11,41 @@
 # https://bugzilla.proxmox.com/show_bug.cgi?id=2424
 
 - block:
+    # net0 bridge changes require the VM to be stopped — hot-unplug fails if running
+    - name: CLOUD INIT - CHECK IF VM IS RUNNING
+      uri:
+        url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/status/current"
+        method: GET
+        headers:
+          Authorization: "PVEAPIToken={{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
+        validate_certs: no
+      register: _ci_vm_status
+      failed_when: false
+
+    - name: CLOUD INIT - STOP VM BEFORE APPLYING CONFIG (was running)
+      uri:
+        url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/status/stop"
+        method: POST
+        headers:
+          Authorization: "PVEAPIToken={{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
+        validate_certs: no
+        body_format: form-urlencoded
+        body: {}
+      when: _ci_vm_status.json.data.status | default('stopped') == 'running'
+
+    - name: CLOUD INIT - WAIT FOR VM TO STOP
+      uri:
+        url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/status/current"
+        method: GET
+        headers:
+          Authorization: "PVEAPIToken={{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
+        validate_certs: no
+      register: _ci_vm_stop_check
+      until: _ci_vm_stop_check.json.data.status == 'stopped'
+      retries: 30
+      delay: 5
+      when: _ci_vm_status.json.data.status | default('stopped') == 'running'
+
     - name: CLOUD INIT - INJECT VARIABLE
       uri:
         url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/config"

--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/vm/vm_clone.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/vm/vm_clone.yaml
@@ -7,7 +7,23 @@
     ####
     ####
 
-    - name: VM CLONE 
+    - name: VM CLONE - CHECK IF DESTINATION VM ID ALREADY EXISTS
+      uri:
+        url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_new_id }}/status/current"
+        method: GET
+        headers:
+          Authorization: "PVEAPIToken={{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
+        validate_certs: no
+        status_code: [200, 500]
+      register: _vm_clone_exists_check
+      failed_when: false
+
+    - name: VM CLONE - SKIP (VM ID {{ vm_new_id }} already exists)
+      debug:
+        msg: "VM ID {{ vm_new_id }} already exists — skipping clone"
+      when: _vm_clone_exists_check.status == 200
+
+    - name: VM CLONE
       uri:
         url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/clone"
         method: POST
@@ -22,14 +38,15 @@
           description: "{{ vm_description }}"
           full: 1
           storage: "{{ proxmox_dest_vm_storage_name | default(omit) }}"
-
+      when: _vm_clone_exists_check.status != 200
       register: proxmox_call
 
     ####
 
-    - name: VM CLONE -  PRINT proxmox_call
+    - name: VM CLONE - PRINT proxmox_call
       debug:
         var: proxmox_call
+      when: _vm_clone_exists_check.status != 200
 
     - name: VM CLONE - BUILD JSON
       set_fact:
@@ -44,7 +61,7 @@
           vm_name: "{{ vm_name }}"
           vm_description: "{{ vm_description }}"
 
-          raw_info: "{{ proxmox_call.json }}" # orig json proxmox
+          raw_info: "{{ proxmox_call.json if _vm_clone_exists_check.status != 200 else {} }}"
 
     - name: VM CLONE - PRINT JSON
       debug:


### PR DESCRIPTION
Fixes #97

## Summary

Two idempotency/robustness fixes for the Proxmox controller role discovered during end-to-end testing on a fresh Proxmox install.

## Changes

**`vm_clone` — skip if destination VM already exists**
- Add a pre-check GET on `vm_new_id` before the clone POST
- Skip the clone (with a debug message) if the destination VM ID already exists on Proxmox
- Guard `VM CLONE - PRINT proxmox_call` with the same condition to avoid undefined variable error
- `raw_info` falls back to `{}` in `BUILD JSON` when the clone was skipped
- Same pattern already used in `vm_create`, `convert_to_template`, `cloudinit_import` (see #95)

**`cloudinit_set_variables` — stop VM before applying config if running**
- Changing `net0` (bridge switch) via the Proxmox API while a VM is running fails with HTTP 400: `hotplug problem - error on hot-unplugging device 'net0' - still busy in guest`
- Add a pre-check that stops the VM if it is running and waits for `stopped` state before the PUT config call
- No-op overhead for the normal flow where the VM is already stopped

## Files Changed

| File | Change |
|---|---|
| `tasks/include/vm/vm_clone.yaml` | Modified — idempotency pre-check |
| `tasks/include/templates/cloudinit_set_variables.yaml` | Modified — stop-if-running guard |

## Testing

Both fixes tested during `range42-context deploy` on `blank_scenario_2_subnets` against a fresh Proxmox install with a locally configured Debian deployer.

## Related Issues

Fixes #97 — relates to #95 (skip-if-exists pattern for vm_create / convert_to_template / cloudinit_import)