### PR TITLE
fix(cloudinit_set_variables): pin MAC on net0 to prevent Proxmox boot-order reset

### DIFF
--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_set_variables.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_set_variables.yaml
@@ -46,6 +46,11 @@
       delay: 5
       when: _ci_vm_status.json.data.status | default('stopped') == 'running'
 
+    - name: CLOUD INIT - COMPUTE MAC FROM VM ID
+      set_fact:
+        _vm_net_mac_effective: "{{ vm_net_virtio_mac | default('52:54:00:%02x:%02x:%02x' % ((vm_id | int // 65536) % 256, (vm_id | int // 256) % 256, vm_id | int % 256)) }}"
+      when: vm_net_virtio_bridge is defined
+
     - name: CLOUD INIT - INJECT VARIABLE
       uri:
         url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/qemu/{{ vm_id }}/config"
@@ -66,7 +71,8 @@
           nameserver: "{{ vm_ci_dns_ips | default(omit)  }}" # format :  1.1.1.1,2.2.2.2
 
           # switch network bridge if vm_net_virtio_bridge is defined (e.g. template on vmbr140 → VM on vmbr142)
-          net0: "{{ ('virtio,bridge=' + vm_net_virtio_bridge) if vm_net_virtio_bridge is defined else omit }}"
+          # MAC is pinned (derived from vm_id) so Proxmox does not silently reset boot order to order=net0
+          net0: "{{ ('virtio,bridge=' + vm_net_virtio_bridge + ',macaddr=' + _vm_net_mac_effective) if vm_net_virtio_bridge is defined else omit }}"
 
           ipconfig0: >-
             {% if vm_ci_ip is defined %}ip={{ vm_ci_ip }}/{{ vm_ci_netmask }}{% if vm_ci_ip_gw is defined %},gw={{ vm_ci_ip_gw }}{% endif %}{% else %}{{ omit }}{% endif %}


### PR DESCRIPTION
Closes #102

## Summary

- Compute a deterministic MAC from `vm_id` (`52:54:00:XX:XX:XX`) before the `CLOUD INIT - INJECT VARIABLE` task
- Include the MAC in the `net0` entry so Proxmox does not silently reset boot order to `order=net0`
- `vm_net_virtio_mac` variable accepted as an override; falls back to computed value

## Why

When `net0` is sent without a MAC, Proxmox resets the VM boot order to `order=net0` → VM PXE-boots instead of booting from `scsi0`. The previous workaround (`boot: order=scsi0` in the PUT body) broke VM templating and was removed in PR #101. This is the correct, non-invasive fix.

## Test plan

- [x] Deploy a scenario (`range42-context deploy`) and verify VMs boot from disk (not PXE) after cloud-init injection
- [x] Re-run `cloudinit_set_variables` on the same VM and verify the MAC is stable (idempotent)
- [x] Run VM-to-template conversion (`qm template`) and verify the template is valid
- [x] Verify `vm_net_virtio_mac` override is respected when explicitly set