### PR TITLE
fix(cloudinit): resize VM disk after import, not the source ISO

### DIFF
--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
@@ -30,19 +30,21 @@
         executable: /bin/bash
       when: _disk_exists_check.rc != 0
 
-    # Resize the imported VM disk to the desired spec size.
-    # qm resize operates on the disk inside Proxmox storage — it does NOT touch
-    # the source cloud image file in /var/lib/vz/template/iso/.
-    - name: RESIZE VM DISK TO {{ vm_disk_size | upper }}
-      shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size | upper }}
-      args:
-        executable: /bin/bash
-      when: _disk_exists_check.rc != 0
-
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
     - name: ENABLE SCSI CONTROLLER AND ATTACH DISK
       shell: qm set {{ vm_id }} --scsihw virtio-scsi-pci --scsi0 {{ proxmox_dest_vm_storage_name }}:vm-{{ vm_id }}-disk-0
+      args:
+        executable: /bin/bash
+      when: _disk_exists_check.rc != 0
+
+    # Resize the imported VM disk to the desired spec size.
+    # Must run after ATTACH DISK — qm disk import creates the disk as unused0,
+    # not scsi0; resize would fail with "disk does not exist" if run before attach.
+    # qm resize operates on the disk inside Proxmox storage — it does NOT touch
+    # the source cloud image file in /var/lib/vz/template/iso/.
+    - name: RESIZE VM DISK TO {{ vm_disk_size | upper }}
+      shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size | upper }}
       args:
         executable: /bin/bash
       when: _disk_exists_check.rc != 0

--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
@@ -22,22 +22,7 @@
         msg: "VM {{ vm_id }} already has scsi0 disk — skipping import"
       when: _disk_exists_check.rc == 0
 
-    - name: debug
-      debug:
-        msg: " qemu-img resize --shrink {{ cloudinit_image_full_path}} {{ vm_disk_size }}"
-      when: _disk_exists_check.rc != 0
-
-    - name: RESIZE DISK
-      shell: qemu-img resize --shrink {{ cloudinit_image_full_path}} {{ vm_disk_size }}
-      args:
-        executable: /bin/bash
-      when: _disk_exists_check.rc != 0
-
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
-
-    # - name: debug
-    #   debug:
-    #     msg: " qm disk import {{ vm_id }} {{ cloudinit_image_full_path }} {{ proxmox_dest_vm_storage_name }}"
 
     - name: QM DISK IMPORT TO {{ vm_id }}
       shell: qm disk import {{ vm_id }} {{ cloudinit_image_full_path }} {{ proxmox_dest_vm_storage_name }}
@@ -45,11 +30,16 @@
         executable: /bin/bash
       when: _disk_exists_check.rc != 0
 
-    #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
+    # Resize the imported VM disk to the desired spec size.
+    # qm resize operates on the disk inside Proxmox storage — it does NOT touch
+    # the source cloud image file in /var/lib/vz/template/iso/.
+    - name: RESIZE VM DISK TO {{ vm_disk_size }}
+      shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size }}
+      args:
+        executable: /bin/bash
+      when: _disk_exists_check.rc != 0
 
-    # - name: debug
-    #   debug:
-    #     msg: " qm set {{ vm_id }} --scsihw virtio-scsi-pci --scsi0 {{ proxmox_dest_vm_storage_name }}:vm-{{ vm_id }}-disk-0"
+    #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
     - name: ENABLE SCSI CONTROLLER AND ATTACH DISK
       shell: qm set {{ vm_id }} --scsihw virtio-scsi-pci --scsi0 {{ proxmox_dest_vm_storage_name }}:vm-{{ vm_id }}-disk-0
@@ -59,10 +49,6 @@
 
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
-    # - name: debug
-    #   debug:
-    #     msg: " qm set {{ vm_id }} --ide2 local:cloudinit,media=cdrom"
-
     - name: ADD CLOUD INIT DRIVE - IDE2
       shell: qm set {{ vm_id }} --ide2 {{ proxmox_dest_vm_storage_name }}:cloudinit,media=cdrom
       args:
@@ -71,10 +57,6 @@
 
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
-    # - name: debug
-    #   debug:
-    #     msg: " qm set {{ vm_id }} --boot c --bootdisk scsi0"
-
     - name: BOOT ORDER CHANGES ON scsi0
       shell: qm set {{ vm_id }} --boot c --bootdisk scsi0
       args:
@@ -82,10 +64,6 @@
       when: _disk_exists_check.rc != 0
 
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
-
-    # - name: debug
-    #   debug:
-    #     msg: " qm set {{ vm_id }} --serial0 socket --vga serial0"
 
     - name: ADD VGA SERIAL CONSOLE
       shell: qm set {{ vm_id }} --serial0 socket --vga serial0
@@ -134,7 +112,6 @@
 #           # scsi0: "local-lvm:0,import-from=local:./iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
 #           # scsi0: "local-lvm:0,import-from=local:iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
 #           # scsi0: "local-lvm:0,import-from=/var/lib/vz/template/iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
-#           # scsi0: "local-lvm:0,import-from=local:iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
 #           # scsi0: "local-lvm:0,import-from=iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
 #           scsi0: "local:iso/ubuntu-24.04-minimal-cloudimg-arm64.qcow2"
 

--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
@@ -22,6 +22,17 @@
         msg: "VM {{ vm_id }} already has scsi0 disk — skipping import"
       when: _disk_exists_check.rc == 0
 
+    # Check whether the existing scsi0 is already at the target size.
+    # Runs only when scsi0 already exists; gates the resize task so a re-run
+    # can self-heal a disk that was attached but never resized (e.g. left at
+    # cloud-image size after a partial deployment).
+    - name: CHECK DISK SIZE (skip resize if scsi0 already {{ vm_disk_size | upper }})
+      shell: qm config {{ vm_id }} | grep 'scsi0:' | grep -q 'size={{ vm_disk_size | upper }}'
+      register: _disk_size_check
+      failed_when: false
+      changed_when: false
+      when: _disk_exists_check.rc == 0
+
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
     - name: QM DISK IMPORT TO {{ vm_id }}
@@ -43,11 +54,12 @@
     # not scsi0; resize would fail with "disk does not exist" if run before attach.
     # qm resize operates on the disk inside Proxmox storage — it does NOT touch
     # the source cloud image file in /var/lib/vz/template/iso/.
+    # Also runs when scsi0 exists but is smaller than target (self-heal path).
     - name: RESIZE VM DISK TO {{ vm_disk_size | upper }}
       shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size | upper }}
       args:
         executable: /bin/bash
-      when: _disk_exists_check.rc != 0
+      when: _disk_exists_check.rc != 0 or (_disk_size_check.rc | default(0)) != 0
 
     #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 

--- a/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
+++ b/roles/range42-ansible_roles-proxmox_controller/tasks/include/templates/cloudinit_import_disk_workaround.yaml
@@ -33,8 +33,8 @@
     # Resize the imported VM disk to the desired spec size.
     # qm resize operates on the disk inside Proxmox storage — it does NOT touch
     # the source cloud image file in /var/lib/vz/template/iso/.
-    - name: RESIZE VM DISK TO {{ vm_disk_size }}
-      shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size }}
+    - name: RESIZE VM DISK TO {{ vm_disk_size | upper }}
+      shell: qm resize {{ vm_id }} scsi0 {{ vm_disk_size | upper }}
       args:
         executable: /bin/bash
       when: _disk_exists_check.rc != 0


### PR DESCRIPTION
## Summary

Closes #104

- Removes `qemu-img resize --shrink` call on the source cloud image file in ISO storage — this was permanently bloating the downloaded `.qcow2` to the full VM disk size (e.g. 500 GiB for `large` templates)
- Replaces it with `qm resize {{ vm_id }} scsi0 {{ vm_disk_size }}` executed **after** `qm disk import`, which resizes the disk inside Proxmox VM storage without touching the source file

## Why this matters

The `large` template spec (`2cpu/8gb/500gb`) passes `vm_disk_size=500G` to `qemu-img resize`, growing a ~500 MB Debian cloud image to 500 GiB on disk. Every subsequent run of `iso_download.yaml` then had to STAT/checksum a 500 GiB file, causing multi-minute delays on the `STAT existing file on proxmox node` task.

## Test plan

- [ ] Delete the bloated ISO file on Proxmox and re-run template creation for `template-vm-debian-trixie-large`
- [ ] Confirm the downloaded `.qcow2` stays at ~500 MB after the run
- [ ] Confirm the VM's `scsi0` disk is 500 GiB inside Proxmox storage (`qm config <vmid> | grep scsi0`)
- [ ] Confirm `iso_download.yaml` STAT task completes in seconds on subsequent runs