### PR TITLE
chore(ci): add CI workflow and Dependabot hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels: [dependencies, ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main, dev, 'feature/**']
+    branches: [main, dev, 'feat/**', 'fix/**']
   pull_request:
     branches: [main, dev]
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
       image: python:3.13-slim
     steps:
       - run: apt-get update && apt-get install -y --no-install-recommends git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: pip install --no-cache-dir ansible-lint
       - run: ansible-lint . --profile=production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main, dev, 'feature/**']
+  pull_request:
+    branches: [main, dev]
+jobs:
+  ansible-lint:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.13-slim
+    steps:
+      - run: apt-get update && apt-get install -y --no-install-recommends git
+      - uses: actions/checkout@v4
+      - run: pip install --no-cache-dir ansible-lint
+      - run: ansible-lint . --profile=production


### PR DESCRIPTION
## Summary

- ansible-lint on python:3.13-slim + github-actions Dependabot

Closes #106 

## Changes
- `.github/workflows/ci.yml` — CI pipeline running in a containerised Debian/Python/Node image
- `.github/dependabot.yml` — automated dependency updates

## Test plan
- [ ] CI runs green on this PR
- [ ] Dependabot alerts enabled in repo settings